### PR TITLE
Add support for tracking plugins installed via PluginInstaller.

### DIFF
--- a/Source/UI/PluginInstaller.h
+++ b/Source/UI/PluginInstaller.h
@@ -35,6 +35,8 @@ private:
     WeakReference<PluginInstaller>::Master masterReference;
     friend class WeakReference<PluginInstaller>;
 
+    void createXmlFile();
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PluginInstaller);
 
 };
@@ -143,6 +145,7 @@ private:
     ListBox pluginList;
     Font listFont;
     int numRows;
+    int maxTextWidth = 0;
 
     String lastPluginSelected; 
     Array<String> pluginVersion;


### PR DESCRIPTION
Also, Change UI layout of PluginInstaller.
Plugin Installer now generates an "installedPlugins.xml" file inside the plugins folder, and adds the entries of new plugins installed via plugin installer. It also checks whether the plugins of the same version exists before downloading a plugin.